### PR TITLE
fix(MangaUpdates): re-throw discover section errors

### DIFF
--- a/src/MangaUpdates/Implementations/DiscoverSection/main.ts
+++ b/src/MangaUpdates/Implementations/DiscoverSection/main.ts
@@ -140,7 +140,7 @@ export class DiscoverSectionImplementation implements DiscoverSectionProviding {
                 `${logPrefix} failed: ${section.id}, page=${body.page}`,
             );
             console.log(e);
-            return { items: [], metadata: -1 };
+            throw e;
         }
     }
 }

--- a/src/MangaUpdates/Implementations/SearchResults/main.ts
+++ b/src/MangaUpdates/Implementations/SearchResults/main.ts
@@ -9,7 +9,6 @@ import {
 import { makeRequest } from "../../Services/Requests";
 import { MangaImplementation } from "../Manga/main";
 import { MU } from "../Shared/models/main";
-import { manga } from "../Shared/parser/main";
 import * as search from "./parser";
 
 const TYPE_LIST = [
@@ -120,9 +119,7 @@ export class SearchResultsImplementation
                         id: g.genre!.replaceAll(" ", "_"),
                         value: g.genre!,
                     })),
-                value: Object.fromEntries(
-                    manga.unsafeGenres.map((id) => [id, "excluded"]),
-                ),
+                value: {},
                 allowExclusion: true,
                 allowEmptySelection: true,
                 maximum: undefined,

--- a/src/MangaUpdates/pbconfig.ts
+++ b/src/MangaUpdates/pbconfig.ts
@@ -4,7 +4,7 @@ export default {
     name: "MangaUpdates",
     description:
         "Extension that integrates with mangaupdates.com for tracking and collection management.",
-    version: "1.0.0-alpha.1",
+    version: "1.0.0-alpha.2",
     icon: "icon.png",
     language: "en",
     contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
This PR fixes an issue where logged-out MangaUpdates users just see an empty discover page, because of a bad error fallback suppressing the exception telling them they're logged out.

I've also removed the default filtering from the search results. I'm still planning to add extension settings to control this, but the current behaviour is more trouble than it's worth, and it's a one line change to make it behave the same as Anilist.