### PR TITLE
feat(MangaUpdates): more permissive auth checks

### DIFF
--- a/src/MangaUpdates/Implementations/DiscoverSection/main.ts
+++ b/src/MangaUpdates/Implementations/DiscoverSection/main.ts
@@ -102,7 +102,12 @@ export class DiscoverSectionImplementation implements DiscoverSectionProviding {
           break;
       }
 
-      const page = await makeRequest("/v1/series/search", "POST", { body }, false);
+      const page = await makeRequest(
+        "/v1/series/search",
+        "POST",
+        { body },
+        { allowAnonymous: true, failOnError: false },
+      );
       const results = (page?.results ?? []).map((r) => r.record);
 
       const items = results

--- a/src/MangaUpdates/Implementations/Manga/main.ts
+++ b/src/MangaUpdates/Implementations/Manga/main.ts
@@ -11,10 +11,12 @@ export class MangaImplementation implements MangaProviding {
     const logPrefix = "[getMangaDetails]";
     console.log(`${logPrefix} start: ${mangaId}`);
 
-    const series = await makeRequest("/v1/series/{id}", "GET", {
-      params: { id: mangaId },
-      query: {},
-    });
+    const series = await makeRequest(
+      "/v1/series/{id}",
+      "GET",
+      { params: { id: mangaId }, query: {} },
+      { allowAnonymous: true },
+    );
 
     const result = {
       mangaId,

--- a/src/MangaUpdates/Implementations/MangaProgress/form.ts
+++ b/src/MangaUpdates/Implementations/MangaProgress/form.ts
@@ -82,7 +82,7 @@ class DeletionForm extends Form {
         "/v1/lists/series/delete",
         "POST",
         { body: [parseInt(this.mangaId)] },
-        false,
+        { failOnError: false },
       );
       if (result == null) {
         throw new Error("Failed to delete.");
@@ -261,18 +261,25 @@ export class MangaProgressForm extends Form {
       console.log(`${logPrefix} start: ${this.mangaId}`);
 
       const [mangaInfo, mangaLists, progressInfo, ratingInfo] = await Promise.all([
-        makeRequest("/v1/series/{id}", "GET", {
-          params: { id: this.mangaId },
-          query: {},
-        }),
+        makeRequest(
+          "/v1/series/{id}",
+          "GET",
+          { params: { id: this.mangaId }, query: {} },
+          { allowAnonymous: true },
+        ),
         makeRequest("/v1/lists", "GET", {}),
         makeRequest(
           "/v1/lists/series/{seriesId}",
           "GET",
           { params: { seriesId: this.mangaId }, query: {} },
-          false,
+          { failOnError: false },
         ),
-        makeRequest("/v1/series/{id}/rating", "GET", { params: { id: this.mangaId } }, false),
+        makeRequest(
+          "/v1/series/{id}/rating",
+          "GET",
+          { params: { id: this.mangaId } },
+          { failOnError: false },
+        ),
       ]);
       console.log(`${logPrefix} data fetch complete: ${this.mangaId}`);
 

--- a/src/MangaUpdates/Implementations/MangaProgress/main.ts
+++ b/src/MangaUpdates/Implementations/MangaProgress/main.ts
@@ -47,11 +47,8 @@ export class MangaProgressImplementation implements MangaProgressProviding {
     const progressInfo = await makeRequest(
       "/v1/lists/series/{seriesId}",
       "GET",
-      {
-        params: { seriesId: sourceManga.mangaId },
-        query: {},
-      },
-      false,
+      { params: { seriesId: sourceManga.mangaId }, query: {} },
+      { failOnError: false },
     );
     if (progressInfo == null) {
       return undefined;
@@ -170,7 +167,7 @@ export class MangaProgressImplementation implements MangaProgressProviding {
         "/v1/lists/series/{seriesId}",
         "GET",
         { params: { seriesId }, query: {} },
-        false,
+        { failOnError: false },
       );
 
       const listChapter = listInfo?.status?.chapter ?? 0;

--- a/src/MangaUpdates/Implementations/SearchResults/form.ts
+++ b/src/MangaUpdates/Implementations/SearchResults/form.ts
@@ -124,15 +124,15 @@ export class MangaUpdatesAdvancedSearchForm extends AdvancedSearchForm {
     }
 
     const [genres, lists] = await Promise.all([
-      makeRequest("/v1/genres", "GET", {}),
-      makeRequest("/v1/lists", "GET", {}),
+      makeRequest("/v1/genres", "GET", {}, { allowAnonymous: true }),
+      makeRequest("/v1/lists", "GET", {}, { failOnError: false }),
     ]);
 
     Application.setState(JSON.stringify(genres), STATE_GENRES);
     Application.setState(JSON.stringify(lists), STATE_LISTS);
     Application.setState(String(new Date().valueOf() / 1000), STATE_QUERY_DATE);
 
-    return { genres, lists };
+    return { genres, lists: lists ?? [] };
   }
 
   override getSections() {

--- a/src/MangaUpdates/Implementations/SearchResults/main.ts
+++ b/src/MangaUpdates/Implementations/SearchResults/main.ts
@@ -99,9 +99,12 @@ export class SearchResultsImplementation
       }
 
       console.log(`${logPrefix} searching: ${JSON.stringify(body)}`);
-      const response = await makeRequest("/v1/series/search", "POST", {
-        body,
-      });
+      const response = await makeRequest(
+        "/v1/series/search",
+        "POST",
+        { body },
+        { allowAnonymous: true },
+      );
 
       const results = search.parseSearchResults(response.results || []);
       const hasNextPage = body.page * body.perpage < (response.total_hits ?? 0);

--- a/src/MangaUpdates/Implementations/SettingsForm/form.ts
+++ b/src/MangaUpdates/Implementations/SettingsForm/form.ts
@@ -77,9 +77,12 @@ export class LoginForm extends Form {
     }
 
     try {
-      const result = await makeRequest("/v1/account/login", "PUT", {
-        body: this.loginForm,
-      });
+      const result = await makeRequest(
+        "/v1/account/login",
+        "PUT",
+        { body: this.loginForm },
+        { allowAnonymous: true },
+      );
       const sessionToken = result.context?.session_token;
       if (!sessionToken) {
         console.log(`${logPrefix} no session token on response: ${JSON.stringify(result)}`);

--- a/src/MangaUpdates/Services/Requests.ts
+++ b/src/MangaUpdates/Services/Requests.ts
@@ -59,15 +59,19 @@ export async function makeRequest<
   V extends MU.Verb<E>,
   F extends boolean = true,
   R = F extends true ? MU.Response<E, V> : MU.Response<E, V> | undefined,
->(endpoint: E, verb: V, request: MU.Request<E, V>, failOnErrorStatus?: F): Promise<R> {
+>(
+  endpoint: E,
+  verb: V,
+  request: MU.Request<E, V>,
+  {
+    allowAnonymous = false,
+    failOnError = true as F,
+  }: { failOnError?: F; allowAnonymous?: boolean } = {},
+): Promise<R> {
   const logPrefix = `[request] ${verb} ${endpoint}`;
-  const isLogin = endpoint === "/v1/account/login";
-  const failOnError = (failOnErrorStatus ?? true) as F;
   const baseRequest: Partial<MU.BaseRequest> = request;
 
-  console.log(
-    `${logPrefix} starts (failOnErrorStatus=${failOnError}): ${loggableRequest(baseRequest)}`,
-  );
+  console.log(`${logPrefix} starts (failOnError=${failOnError}): ${loggableRequest(baseRequest)}`);
 
   const path = Object.entries(baseRequest.params || {})
     .filter((entry) => entry[1] != undefined)
@@ -91,9 +95,16 @@ export async function makeRequest<
   if (baseRequest.body) {
     headers["content-type"] = "application/json";
   }
-  if (!isLogin) {
-    session.assertMustBeAuthenticated();
-    const sessionToken = session.getSessionToken()!;
+
+  const sessionToken = session.getSessionToken();
+  if (!allowAnonymous) {
+    if (failOnError) {
+      session.assertMustBeAuthenticated();
+    } else if (!sessionToken) {
+      return undefined as R;
+    }
+  }
+  if (sessionToken) {
     headers.authorization = `Bearer ${sessionToken}`;
   }
 

--- a/src/MangaUpdates/pbconfig.ts
+++ b/src/MangaUpdates/pbconfig.ts
@@ -7,7 +7,7 @@ export default {
   name: "MangaUpdates",
   description:
     "Extension that integrates with mangaupdates.com for tracking and collection management.",
-  version: "1.0.0-alpha.6",
+  version: "1.0.0-alpha.7",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
Previously, the MangaUpdates tracker required auth for all requests (because this makes it more obvious that tracking will not work unless you're logged in). However, this breaks the new tests as they are unauthenticated.

This PR updates the MangaUpdates tracker to check auth only when the actual endpoint requires it. The test suite passes after this change.